### PR TITLE
Fixed empty comment bug

### DIFF
--- a/src/js/components/pages/LessonResponse.js
+++ b/src/js/components/pages/LessonResponse.js
@@ -164,7 +164,7 @@ class LessonResponsePage extends Component {
               <div className="structured_panel">
                 <h1>Video Response</h1>
                 <YoutubeVideo vid={this.lesson.response_video}/>
-                <h1>Comments</h1>
+                {this.lesson.response_notes !== '' && <h1>Comments</h1>}
                 {convertTextToP(this.lesson.response_notes)}
               </div>
             </section>

--- a/src/js/utils/utils.js
+++ b/src/js/utils/utils.js
@@ -9,13 +9,13 @@
   };
 
   export function convertTextToLine(string){
-    if(!string.length){return null;}
+    if(!string.length){return '';}
     
     let array = string.split(":::");
     return array.join('\r\n\r\n');
   }
   export function convertLineToText(string){
-    if(!string.length){return null;}
+    if(!string.length){return '';}
 
     let array = string.split(/[\r\n]+/);
     return array.join(':::');


### PR DESCRIPTION
Fixes the bug where an administrator cannot submit a lesson response with an empty comments field. Also, does not show the comments header for a user if there are no comments.